### PR TITLE
feat: add support for KafkaDependentProducer instrumentation

### DIFF
--- a/src/Confluent.Kafka.Extensions.Diagnostics/DependentProducerBuilderExtensions.cs
+++ b/src/Confluent.Kafka.Extensions.Diagnostics/DependentProducerBuilderExtensions.cs
@@ -1,0 +1,19 @@
+namespace Confluent.Kafka.Extensions.Diagnostics;
+
+/// <summary>
+///     Extension methods for <see cref="DependentProducerBuilder{TKey,TValue}" />.
+/// </summary>
+public static class DependentProducerBuilderExtensions
+{
+    /// <summary>
+    ///     Builds a new instrumented instance of producer.
+    /// </summary>
+    public static IProducer<TKey, TValue> BuildWithInstrumentation<TKey, TValue>(
+        this DependentProducerBuilder<TKey, TValue> producerBuilder
+    )
+    {
+        if (producerBuilder == null) throw new ArgumentNullException(nameof(producerBuilder));
+
+        return new InstrumentedProducer<TKey, TValue>(producerBuilder.Build());
+    }
+}

--- a/tests/Confluent.Kafka.Extensions.Diagnostics.Tests/KafkaDiagnosticsTests.cs
+++ b/tests/Confluent.Kafka.Extensions.Diagnostics.Tests/KafkaDiagnosticsTests.cs
@@ -59,7 +59,7 @@ public sealed class KafkaDiagnosticsTests : IAssemblyFixture<EnvironmentFixture>
         ActivitySource.AddActivityListener(listener);
 
         // Act
-        await _dependentProducer.ProduceAsync("produce_async_topic",
+        await _dependentProducer.ProduceAsync("dependent_produce_async_topic",
             new Message<string, string> { Key = "test", Value = "Hello World!" });
     }
 
@@ -77,7 +77,7 @@ public sealed class KafkaDiagnosticsTests : IAssemblyFixture<EnvironmentFixture>
         var delivered = false;
 
         // Act
-        _dependentProducer.Produce("produce_topic",
+        _dependentProducer.Produce("dependent_produce_topic",
             new Message<string, string> { Key = "test", Value = "Hello World!" }, report =>
             {
                 delivered = true;

--- a/tests/Confluent.Kafka.Extensions.Diagnostics.Tests/__snapshots__/KafkaDiagnosticsTests.DependentProduce.snap
+++ b/tests/Confluent.Kafka.Extensions.Diagnostics.Tests/__snapshots__/KafkaDiagnosticsTests.DependentProduce.snap
@@ -1,0 +1,59 @@
+﻿{
+  "Status": "Ok",
+  "StatusDescription": null,
+  "HasRemoteParent": false,
+  "Kind": "Producer",
+  "OperationName": "produce_topic publish",
+  "DisplayName": "produce_topic publish",
+  "Source": {
+    "Name": "Confluent.Kafka.Extensions.Diagnostics",
+    "Version": ""
+  },
+  "Parent": null,
+  "ParentId": null,
+  "Tags": [
+    {
+      "Key": "messaging.system",
+      "Value": "kafka"
+    },
+    {
+      "Key": "messaging.operation",
+      "Value": "publish"
+    },
+    {
+      "Key": "messaging.destination.kind",
+      "Value": "topic"
+    },
+    {
+      "Key": "messaging.destination.name",
+      "Value": "produce_topic"
+    },
+    {
+      "Key": "messaging.kafka.destination.partition",
+      "Value": "0"
+    },
+    {
+      "Key": "messaging.kafka.message.offset",
+      "Value": "0"
+    }
+  ],
+  "Events": [],
+  "Links": [],
+  "Baggage": [],
+  "Context": {
+    "TraceId": {},
+    "SpanId": {},
+    "TraceFlags": "None",
+    "TraceState": null,
+    "IsRemote": false
+  },
+  "TraceStateString": null,
+  "SpanId": {},
+  "TraceId": {},
+  "Recorded": false,
+  "IsAllDataRequested": false,
+  "ActivityTraceFlags": "None",
+  "ParentSpanId": {},
+  "IsStopped": true,
+  "IdFormat": "W3C"
+}

--- a/tests/Confluent.Kafka.Extensions.Diagnostics.Tests/__snapshots__/KafkaDiagnosticsTests.DependentProduceAsync.snap
+++ b/tests/Confluent.Kafka.Extensions.Diagnostics.Tests/__snapshots__/KafkaDiagnosticsTests.DependentProduceAsync.snap
@@ -1,0 +1,59 @@
+﻿{
+  "Status": "Ok",
+  "StatusDescription": null,
+  "HasRemoteParent": false,
+  "Kind": "Producer",
+  "OperationName": "produce_async_topic publish",
+  "DisplayName": "produce_async_topic publish",
+  "Source": {
+    "Name": "Confluent.Kafka.Extensions.Diagnostics",
+    "Version": ""
+  },
+  "Parent": null,
+  "ParentId": null,
+  "Tags": [
+    {
+      "Key": "messaging.system",
+      "Value": "kafka"
+    },
+    {
+      "Key": "messaging.operation",
+      "Value": "publish"
+    },
+    {
+      "Key": "messaging.destination.kind",
+      "Value": "topic"
+    },
+    {
+      "Key": "messaging.destination.name",
+      "Value": "produce_async_topic"
+    },
+    {
+      "Key": "messaging.kafka.destination.partition",
+      "Value": "0"
+    },
+    {
+      "Key": "messaging.kafka.message.offset",
+      "Value": "1"
+    }
+  ],
+  "Events": [],
+  "Links": [],
+  "Baggage": [],
+  "Context": {
+    "TraceId": {},
+    "SpanId": {},
+    "TraceFlags": "None",
+    "TraceState": null,
+    "IsRemote": false
+  },
+  "TraceStateString": null,
+  "SpanId": {},
+  "TraceId": {},
+  "Recorded": false,
+  "IsAllDataRequested": false,
+  "ActivityTraceFlags": "None",
+  "ParentSpanId": {},
+  "IsStopped": true,
+  "IdFormat": "W3C"
+}


### PR DESCRIPTION
Add support for KafkaDependentProducer that allows to produce messages with different types using a single producer instance.

Using KafkaDependentProducer is more efficient than creating more than one kafka producer instance.